### PR TITLE
Supporting Cloudant DB

### DIFF
--- a/Sources/CouchDBClient/CouchDBClient.swift
+++ b/Sources/CouchDBClient/CouchDBClient.swift
@@ -889,7 +889,7 @@ internal extension CouchDBClient {
 
 		var cookie = ""
 		response.headers.forEach { (header: (name: String, value: String)) in
-			if header.name == "Set-Cookie" {
+			if header.name.lowercased() == "set-cookie" {
 				cookie = header.value
 			}
 		}


### PR DESCRIPTION
While trying to use couchdb-vapor with Cloudant I was getting 'unauthorized' errors due to IBM Cloudant sending back 'set-cookie' as lowercased in the response header. By lowercasing the cookie header before comparing we could cover more scenarios from more service providers.