### PR TITLE
2.3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Package.resolved
 /Packages
 /*.xcodeproj
 .swiftpm
+test.sh

--- a/Sources/CouchDBClient/CouchDBClient.swift
+++ b/Sources/CouchDBClient/CouchDBClient.swift
@@ -1759,10 +1759,13 @@ internal extension CouchDBClient {
 		var request = HTTPClientRequest(url: url)
 		request.method = .POST
 		request.headers.add(name: "Content-Type", value: "application/x-www-form-urlencoded")
-		let encodedUserName = userName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-		let encodedPassword = userPassword.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-		let dataString = "name=\(encodedUserName)&password=\(encodedPassword)"
-		request.body = .bytes(ByteBuffer(string: dataString))
+		var bodyComponents = URLComponents()
+		bodyComponents.queryItems = [
+			URLQueryItem(name: "name", value: userName),
+			URLQueryItem(name: "password", value: userPassword)
+		]
+		let bodyString = bodyComponents.percentEncodedQuery ?? ""
+		request.body = .bytes(ByteBuffer(string: bodyString))
 
 		let response =
 			try await httpClient
@@ -1781,17 +1784,13 @@ internal extension CouchDBClient {
 
 		if let httpCookie = HTTPClient.Cookie(header: cookie, defaultDomain: self.couchHost) {
 			if httpCookie.expires == nil {
-				let formatter = DateFormatter()
-				formatter.dateFormat = "E, dd-MMM-yyyy HH:mm:ss z"
-
 				let expiresString = cookie.split(separator: ";")
 					.map({ $0.trimmingCharacters(in: .whitespaces) })
 					.first(where: { $0.hasPrefix("Expires=") })?
 					.split(separator: "=").last
 
 				if let expiresString = expiresString {
-					let expires = formatter.date(from: String(expiresString))
-					sessionCookieExpires = expires
+					sessionCookieExpires = Self.parseCookieExpires(String(expiresString))
 				}
 			} else {
 				sessionCookieExpires = httpCookie.expires
@@ -1823,5 +1822,24 @@ internal extension CouchDBClient {
 		request.method = method
 		request.headers = headers
 		return request
+	}
+
+	static func parseCookieExpires(_ expiresString: String) -> Date? {
+		// Common cookie Expires formats seen in the wild.
+		let formats = [
+			"E, dd MMM yyyy HH:mm:ss zzz",
+			"E, dd-MMM-yyyy HH:mm:ss zzz",
+			"E, dd-MMM-yyyy HH:mm:ss z"
+		]
+		for format in formats {
+			let formatter = DateFormatter()
+			formatter.locale = Locale(identifier: "en_US_POSIX")
+			formatter.timeZone = TimeZone(secondsFromGMT: 0)
+			formatter.dateFormat = format
+			if let date = formatter.date(from: expiresString) {
+				return date
+			}
+		}
+		return nil
 	}
 }

--- a/Tests/CouchDBClientTests/CouchDBClientTests.swift
+++ b/Tests/CouchDBClientTests/CouchDBClientTests.swift
@@ -72,7 +72,7 @@ struct CouchDBClientTests {
 		var testDoc = ExpectedDoc(name: "test name")
 		testDoc = try await couchDBClient.insert(dbName: testsDB, doc: testDoc)
 		let expectedInsertId = testDoc._id
-		let expectedInsertRev = testDoc._rev!
+		let expectedInsertRev = try #require(testDoc._rev)
 
 		testDoc = try await couchDBClient.get(fromDB: testsDB, uri: expectedInsertId)
 
@@ -85,9 +85,11 @@ struct CouchDBClientTests {
 		let getResponse2 = try await couchDBClient.get(fromDB: testsDB, uri: expectedInsertId)
 		let expectedBytes2 = getResponse2.headers.first(name: "content-length").flatMap(Int.init) ?? 1024 * 1024 * 10
 		var bytes2 = try await getResponse2.body.collect(upTo: expectedBytes2)
-		let data2 = bytes2.readData(length: bytes2.readableBytes)
+		guard let data2 = bytes2.readData(length: bytes2.readableBytes) else {
+			throw CouchDBClientError.noData
+		}
 
-		testDoc = try JSONDecoder().decode(ExpectedDoc.self, from: data2!)
+		testDoc = try JSONDecoder().decode(ExpectedDoc.self, from: data2)
 		#expect(expectedName == testDoc.name)
 
 		let response = try await couchDBClient.delete(fromDb: testsDB, doc: testDoc)
@@ -116,8 +118,10 @@ struct CouchDBClientTests {
 		let expectedBytes = getResponse.headers.first(name: "content-length").flatMap(Int.init) ?? 1024 * 1024 * 10
 		var bytes = try await getResponse.body.collect(upTo: expectedBytes)
 
-		let data = bytes.readData(length: bytes.readableBytes)
-		testDoc = try JSONDecoder().decode(ExpectedDoc.self, from: data!)
+		guard let data = bytes.readData(length: bytes.readableBytes) else {
+			throw CouchDBClientError.noData
+		}
+		testDoc = try JSONDecoder().decode(ExpectedDoc.self, from: data)
 
 		#expect(expectedName == testDoc.name)
 		#expect(testDoc._rev == expectedInsertRev)
@@ -143,15 +147,18 @@ struct CouchDBClientTests {
 		let expectedBytes2 = getResponse2.headers.first(name: "content-length").flatMap(Int.init) ?? 1024 * 1024 * 10
 		var bytes2 = try await getResponse2.body.collect(upTo: expectedBytes2)
 
-		let data2 = bytes2.readData(length: bytes2.readableBytes)
-		testDoc = try JSONDecoder().decode(ExpectedDoc.self, from: data2!)
+		guard let data2 = bytes2.readData(length: bytes2.readableBytes) else {
+			throw CouchDBClientError.noData
+		}
+		testDoc = try JSONDecoder().decode(ExpectedDoc.self, from: data2)
 
 		#expect(expectedName == testDoc.name)
 
+		let rev = try #require(testDoc._rev)
 		let deleteResponse = try await couchDBClient.delete(
 			fromDb: testsDB,
 			uri: testDoc._id,
-			rev: testDoc._rev!
+			rev: rev
 		)
 		#expect(deleteResponse.ok == true)
 		#expect(!deleteResponse.id.isEmpty)
@@ -222,13 +229,15 @@ struct CouchDBClientTests {
 		let docs: [ExpectedDoc] = try await couchDBClient.find(inDB: testsDB, query: query)
 
 		#expect(docs.count > 0)
-		let id = try #require(docs.first?._id)
+		let firstDoc = try #require(docs.first)
+		let id = firstDoc._id
 		#expect(id == insertResponse.id)
 
+		let rev = try #require(firstDoc._rev)
 		_ = try await couchDBClient.delete(
 			fromDb: testsDB,
-			uri: docs.first!._id,
-			rev: docs.first!._rev!
+			uri: firstDoc._id,
+			rev: rev
 		)
 	}
 

--- a/Tests/CouchDBClientTests/MangoQueryTests.swift
+++ b/Tests/CouchDBClientTests/MangoQueryTests.swift
@@ -90,10 +90,11 @@ struct MangoQueryTests {
 				"boolValue": true,
 				"arrayValue": [1, "two", true]
 			}
-			""".data(using: .utf8)!
+			"""
+		let jsonData = try #require(json.data(using: .utf8))
 
 		let decoder = JSONDecoder()
-		let dictionary = try decoder.decode([String: MangoValue].self, from: json)
+		let dictionary = try decoder.decode([String: MangoValue].self, from: jsonData)
 
 		#expect(dictionary["stringValue"] != nil)
 		#expect(dictionary["intValue"] != nil)


### PR DESCRIPTION
## Summary
- Fix CouchDB `_session` auth body encoding by generating a proper `application/x-www-form-urlencoded` payload (handles special characters in username/password).
- Improve parsing of session cookie `Expires=` attribute across common date formats to reduce unnecessary re-auth.
- Harden tests by removing force-unwraps and using `#require`/`guard` for clearer failures.

## Notes
- No public API changes; intended as a patch release.